### PR TITLE
Interop support for tRPC v11

### DIFF
--- a/packages/adapters/aws-lambda.ts
+++ b/packages/adapters/aws-lambda.ts
@@ -5,6 +5,7 @@ import type { Context as APIGWContext } from "aws-lambda"
 import { EventEmitter } from "events"
 import type { RequestMethod } from "node-mocks-http"
 import { createRequest, createResponse } from "node-mocks-http"
+import { getErrorShape } from "@trpc/server/shared"
 
 // Application Sectional || Define Imports
 // =================================================================================================
@@ -142,7 +143,8 @@ export const createOpenApiAwsLambdaHandler = <TRouter extends OpenApiRouter, TEv
         errors: [error]
       })
 
-      const errorShape = opts.router.getErrorShape({
+      const errorShape = getErrorShape({
+        config: opts.router._def._config,
         error,
         type: "unknown",
         path,

--- a/packages/adapters/fetch.ts
+++ b/packages/adapters/fetch.ts
@@ -1,23 +1,44 @@
-import { TRPCError } from "@trpc/server"
-import { FetchHandlerOptions } from "@trpc/server/adapters/fetch"
+import { AnyRouter, TRPCError } from "@trpc/server"
+import { FetchCreateContextOption, FetchHandlerOptions } from "@trpc/server/adapters/fetch"
 import { IncomingMessage, ServerResponse } from "http"
 
 // Application Sectional || Define Imports
 // =================================================================================================
 // =================================================================================================
+import { HTTPBaseHandlerOptions } from "@trpc/server/dist/http"
 import { OpenApiRouter } from "../types"
 import { CreateOpenApiNodeHttpHandlerOptions, createOpenApiNodeHttpHandler } from "./node-http/core"
 
 // Application Sectional || Define Export Type
 // =================================================================================================
 // =================================================================================================
-export type CreateOpenApiFetchHandlerOptions<TRouter extends OpenApiRouter> = Omit<FetchHandlerOptions<TRouter>, "batching"> & {
+
+/**
+ * Temporary wrapper type for tRPC v11 compatibility
+ */
+export type FetchHandlerOptionsWrapper<T extends OpenApiRouter> = FetchCreateContextOption<T & {
+  getErrorShape: () => any;
+  createCaller: () => any;
+}> & HTTPBaseHandlerOptions<T & {
+  getErrorShape: () => any;
+  createCaller: () => any;
+}, Request>;
+
+export type CreateOpenApiFetchHandlerOptions<
+  TRouter extends OpenApiRouter
+> = Omit<
+  FetchHandlerOptionsWrapper<TRouter & {
+    getErrorShape: () => any;
+    createCaller: () => any;
+  }>,
+  "batching"
+> & {
   req: Request;
-  endpoint: `/${string}`
+  endpoint: `/${string}`;
   cors?: {
-    origin: string
-    methods?: string[]
-    headers?: string[]
+    origin: string;
+    methods?: string[];
+    headers?: string[];
   }
 };
 

--- a/packages/adapters/node-http/core.ts
+++ b/packages/adapters/node-http/core.ts
@@ -1,4 +1,4 @@
-import { AnyProcedure, TRPCError } from "@trpc/server"
+import { AnyProcedure, callProcedure, procedureTypes, TRPCError, ProcedureType, Router, AnyRouterDef } from "@trpc/server"
 import {
   NodeHTTPHandlerOptions,
   NodeHTTPRequest,
@@ -6,8 +6,9 @@ import {
 } from "@trpc/server/dist/adapters/node-http"
 import cloneDeep from "lodash.clonedeep"
 import { ZodError, z } from "zod"
-import { getErrorShape } from "@trpc/server/shared"
+import { createRecursiveProxy, getErrorShape } from "@trpc/server/shared"
 
+import { AnyRootConfig, RouterCaller } from "@trpc/server/src"
 import { generateOpenApiDocument } from "../../generator"
 import {
   OpenApiErrorResponse,
@@ -30,17 +31,58 @@ import { TRPC_ERROR_CODE_HTTP_STATUS, getErrorFromUnknown } from "./errors"
 import { getBody, getQuery } from "./input"
 import { createProcedureCache } from "./procedures"
 
-
 export type CreateOpenApiNodeHttpHandlerOptions<
   TRouter extends OpenApiRouter,
   TRequest extends NodeHTTPRequest,
   TResponse extends NodeHTTPResponse,
 > = Pick<
-  NodeHTTPHandlerOptions<TRouter, TRequest, TResponse>,
+  NodeHTTPHandlerOptions<TRouter & {
+    getErrorShape: () => any;
+    createCaller: () => any;
+  }, TRequest, TResponse>,
   "router" | "createContext" | "responseMeta" | "onError" | "maxBodySize"
 >;
 
 export type OpenApiNextFunction = () => void;
+
+/**
+ * Temporary wrapper type for tRPC v11 compatibility
+ */
+function createCallerFactory<TConfig extends AnyRootConfig>() {
+  return function createCallerInner<TRouter extends Router<AnyRouterDef<TConfig>>>(router: TRouter): RouterCaller<TRouter["_def"]> {
+    const def = router._def
+    return function createCaller(ctx) {
+      const proxy = createRecursiveProxy(({ path, args }) => {
+        // interop mode
+        if (path.length === 1 && procedureTypes.includes(path[0] as ProcedureType)) {
+          return callProcedure({
+            procedures: def.procedures,
+            path: args[0] as string,
+            rawInput: args[1],
+            ctx,
+            type: path[0] as ProcedureType
+          })
+        }
+        const fullPath = path.join(".")
+        const procedure = def.procedures[fullPath]
+        let type = "query"
+        if (procedure._def.mutation) {
+          type = "mutation"
+        } else if (procedure._def.subscription) {
+          type = "subscription"
+        }
+        return procedure({
+          path: fullPath,
+          rawInput: args[0],
+          getRawInput: () => args[0],
+          ctx,
+          type
+        })
+      })
+      return proxy as ReturnType<RouterCaller<any>>
+    }
+  }
+}
 
 export const createOpenApiNodeHttpHandler = <
   TRouter extends OpenApiRouter,
@@ -128,7 +170,7 @@ export const createOpenApiNodeHttpHandler = <
       }
 
       ctx = await createContext?.({ req, res })
-      const caller = router.createCaller(ctx)
+      const caller = createCallerFactory()(router)(ctx)
 
       const segments = procedure.path.split(".")
       const procedureFn = segments.reduce((acc, curr) => acc[curr], caller as any) as AnyProcedure

--- a/packages/adapters/node-http/core.ts
+++ b/packages/adapters/node-http/core.ts
@@ -6,6 +6,7 @@ import {
 } from "@trpc/server/dist/adapters/node-http"
 import cloneDeep from "lodash.clonedeep"
 import { ZodError, z } from "zod"
+import { getErrorShape } from "@trpc/server/shared"
 
 import { generateOpenApiDocument } from "../../generator"
 import {
@@ -29,6 +30,7 @@ import { TRPC_ERROR_CODE_HTTP_STATUS, getErrorFromUnknown } from "./errors"
 import { getBody, getQuery } from "./input"
 import { createProcedureCache } from "./procedures"
 
+
 export type CreateOpenApiNodeHttpHandlerOptions<
   TRouter extends OpenApiRouter,
   TRequest extends NodeHTTPRequest,
@@ -45,8 +47,8 @@ export const createOpenApiNodeHttpHandler = <
   TRequest extends NodeHTTPRequest,
   TResponse extends NodeHTTPResponse,
 >(
-    opts: CreateOpenApiNodeHttpHandlerOptions<TRouter, TRequest, TResponse>
-  ) => {
+  opts: CreateOpenApiNodeHttpHandlerOptions<TRouter, TRequest, TResponse>
+) => {
   const router = cloneDeep(opts.router)
 
   // Validate router
@@ -166,8 +168,8 @@ export const createOpenApiNodeHttpHandler = <
         errors: [error]
       })
 
-      // VERC: Catalog Change - @trpc/server v11.0.0-next-beta.318
-      const errorShape = router.getErrorShape({
+      const errorShape = getErrorShape({
+        config: router._def._config,
         error,
         type: procedure?.type ?? "unknown",
         path: procedure?.path,

--- a/packages/adapters/node-http/procedures.ts
+++ b/packages/adapters/node-http/procedures.ts
@@ -15,9 +15,10 @@ export const createProcedureCache = (router: OpenApiRouter) => {
     >
   >()
 
-  const { queries, mutations } = router._def
+  const { procedures } = router._def
 
-  forEachOpenApiProcedure(queries, ({ path: queryPath, procedure, openapi }) => {
+  forEachOpenApiProcedure(procedures, ({ path: queryPath, type, procedure, openapi }) => {
+    if (type === "subscription") return
     const { method } = openapi
     if (!procedureCache.has(method)) {
       procedureCache.set(method, new Map())
@@ -25,22 +26,8 @@ export const createProcedureCache = (router: OpenApiRouter) => {
     const path = normalizePath(openapi.path)
     const pathRegExp = getPathRegExp(path)
     procedureCache.get(method)!.set(pathRegExp, {
-      type: "query",
+      type,
       path: queryPath,
-      procedure
-    })
-  })
-
-  forEachOpenApiProcedure(mutations, ({ path: mutationPath, procedure, openapi }) => {
-    const { method } = openapi
-    if (!procedureCache.has(method)) {
-      procedureCache.set(method, new Map())
-    }
-    const path = normalizePath(openapi.path)
-    const pathRegExp = getPathRegExp(path)
-    procedureCache.get(method)!.set(pathRegExp, {
-      type: "mutation",
-      path: mutationPath,
       procedure
     })
   })

--- a/packages/generator/paths.ts
+++ b/packages/generator/paths.ts
@@ -25,10 +25,8 @@ export const getOpenApiPathsObject = (
 
     try {
       if (type === "subscription") {
-        throw new TRPCError({
-          message: "Subscriptions are not supported by OpenAPI v3",
-          code: "INTERNAL_SERVER_ERROR"
-        })
+        console.warn(`[${procedureName}] - Subscriptions are not supported by OpenAPI v3`)
+        return
       }
 
       const { method, protect, summary, description, tags, headers } = openapi

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -54,7 +54,7 @@ export type OpenApiProcedure<TMeta = TRPCMeta> = Procedure<
 
 export type OpenApiProcedureRecord<TMeta = TRPCMeta> = Record<string, OpenApiProcedure<TMeta>>;
 
-export type OpenApiRouter<TMeta = TRPCMeta> = Router<
+export type OpenApiRouter<TMeta = TRPCMeta> = Omit<Router<
   RouterDef<
     RootConfig<{
       transformer: any;
@@ -65,7 +65,7 @@ export type OpenApiRouter<TMeta = TRPCMeta> = Router<
     any,
     any
   >
->;
+>, "getErrorShape" | "createCaller">
 
 export type OpenApiSuccessResponse<D = any> = D;
 

--- a/packages/utils/procedure.ts
+++ b/packages/utils/procedure.ts
@@ -25,9 +25,10 @@ export const getInputOutputParsers = (procedure: OpenApiProcedure) => {
 }
 
 const getProcedureType = (procedure: OpenApiProcedure): ProcedureType => {
-  if (procedure._def.query) return "query"
-  if (procedure._def.mutation) return "mutation"
-  if (procedure._def.subscription) return "subscription"
+  if ("query" in procedure._def && procedure._def.query) return "query"
+  if ("mutation" in procedure._def && procedure._def.mutation) return "mutation"
+  if ("subscription" in procedure._def && procedure._def.subscription) return "subscription"
+  if ("type" in procedure._def && typeof procedure._def.type === "string" && ["query", "mutation", "subscription"].includes(procedure._def.type)) return procedure._def.type as ProcedureType
   throw new Error("Unknown procedure type")
 }
 


### PR DESCRIPTION
This patches certain type constraints that were removed in tRPC v11, therefore allowing users already on v11 to use this package. Tested in environments using both tRPC v10 and v11 using `createOpenApiFetchHandler`. I cannot guarantee there won't be trouble for uses of AWS though, or if this is fully backwards compatible for tRPC v9, but this should unblock most users of #11 until a full package migration happens.

Also removed the error if you have any subscription endpoints in your openAPI docs, instead we should just be skipping over those since they aren't part of the RESTful spec.

tRPC v11 environment: 11.0.0-rc.730
tRPC v10 environment: 10.45.2